### PR TITLE
Explore other pages from search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ Once everything is loaded `M-x ytel` creates a new buffer and puts it in `ytel-m
 
 | key | binding                     |
 |-----|-----------------------------|
-| n   | `next-line`                 |
-| p   | `previous-line`             |
-| q   | `ytel-quit`                 |
-| s   | `ytel-search`               |
-| S   | `ytel-search-replace`       |
-| r   | `ytel-delete-current-video` |
+| `n` | `next-line`                 |
+| `p` | `previous-line`             |
+| `q` | `ytel-quit`                 |
+| `s` | `ytel-search`               |
+| `S` | `ytel-search-replace`       |
+| `r` | `ytel-delete-current-video` |
 
 Pressing `s` will prompt for some search terms and populate the buffer once the results are available. Performing more searches with `s` will add videos to the buffer; videos can be removed by pressing `r` and a "fresh" search can be run with `S`. One can access information about a video via the function `ytel-get-current-video` that returns the video at point. Videos returned by `ytel-get-current-video` are cl-structures so you can access their fields with the `ytel-video-*` functions. Currently videos have four fields:
 

--- a/ytel.el
+++ b/ytel.el
@@ -133,7 +133,7 @@ The formatting is actually terrible, but this is not final."
 
 (defun ytel--draw-buffer (&optional restore-point)
   "Draws the ytel buffer i.e.
-    clear everything and write down all videos in `ytel-videos'.
+clear everything and write down all videos in `ytel-videos'.
     If RESTORE-POINT is 't then restore the cursor line position."
   (let ((inhibit-read-only t)
 	(current-line      (line-number-at-pos)))
@@ -167,14 +167,14 @@ Redraw the buffer."
 
 
 (defun ytel-search-next-page ()
-  "Switch to the next page of the previous search. Redraw the buffer."
+  "Switch to the next page of the previous search.  Redraw the buffer."
   (interactive)
   (set 'ytel-current-page (+ ytel-current-page 1))
   (setf ytel-videos (ytel--query ytel-search-term))
   (ytel--draw-buffer))
 
 (defun ytel-search-previous-page ()
-  "Switch to the next page of the previous search. Redraw the buffer."
+  "Switch to the next page of the previous search.  Redraw the buffer."
   (interactive)
   (when (> ytel-current-page 1)
     (set 'ytel-current-page (- ytel-current-page 1)))

--- a/ytel.el
+++ b/ytel.el
@@ -233,9 +233,9 @@ zero exit code otherwise the request body is parsed by `json-read' and returned.
 
 (defun ytel--query (string)
   "Query youtube for STRING."
-  (let ((videos (ytel--API-call "search" `(("q" .      ,string)
-					   ("page" . ,(number-to-string ytel-current-page))
-					   ("fields" . ,ytel-invidious-default-query-fields)))))
+  (let ((videos (ytel--API-call "search" `(("q" ,string)
+					   ("page" ,(number-to-string ytel-current-page))
+					   ("fields" ,ytel-invidious-default-query-fields)))))
     (dotimes (i (length videos))
       (let ((v (aref videos i)))
 	(aset videos i

--- a/ytel.el
+++ b/ytel.el
@@ -160,6 +160,8 @@ The formatting is actually terrible, but this is not final."
   "Search youtube for `QUERY' and override `ytel-videos' with the results.
 Redraw the buffer."
   (interactive "sSearch terms: ")
+  (set 'ytel-current-page 1)
+  (set 'ytel-search-term query)
   (setf ytel-videos (ytel--query query))
   (ytel--draw-buffer))
 


### PR DESCRIPTION
I think this is a much more intuitive way to search the next page of a search. Simply pressing the "<,>" keys to navigate forward and backward. I also added a header so you can see in which page you're in, with the potential of adding other kind of useful information. 
![image](https://user-images.githubusercontent.com/39146629/82001314-24436700-9618-11ea-8df6-945d350b6e71.png)
![image](https://user-images.githubusercontent.com/39146629/82001336-32918300-9618-11ea-9c1e-a68197553ded.png)

Let me know what you think.