### PR TITLE
Call ytel-search if ytel is empty

### DIFF
--- a/ytel.el
+++ b/ytel.el
@@ -235,7 +235,7 @@ too long).")
   (unless (eq major-mode 'ytel-mode)
     (ytel-mode))
   (when (seq-empty-p ytel-search-term)
-    (setq header-line-format "Press s to start a new search.")))
+    (call-interactively #'ytel-search)))
 
 ;; Youtube interface stuff below.
 (cl-defstruct (ytel-video (:constructor ytel-video--create)


### PR DESCRIPTION
The idea is to avoid calling ytel-search manually there is no search achieved yet.
So if `ytel-search-term` is empty, `ytel-search` is directly called after ytel buffer is spawned.