### PR TITLE
Adds date limiting function and a keybinding to rotate through them

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,16 @@ While `ytel` does not depend on any Emacs package it does depend on `curl` so, i
 ## Usage
 Once everything is loaded `M-x ytel` creates a new buffer and puts it in `ytel-mode`. This major mode has just a few bindings (for now):
 
-| key          | binding                     |
-|--------------|-----------------------------|
-| <key>n</key> | `next-line`                 |
-| <key>p</key> | `previous-line`             |
-| <key>q</key> | `ytel-quit`                 |
-| <key>s</key> | `ytel-search`               |
-| <key>></key> | `ytel-search-next-page`     |
-| <key><</key> | `ytel-search-previous-page` |
+| key          | binding                      |
+|--------------|------------------------------|
+| <key>n</key> | `next-line`                  |
+| <key>p</key> | `previous-line`              |
+| <key>q</key> | `ytel-quit`                  |
+| <key>s</key> | `ytel-search`                |
+| <key>></key> | `ytel-search-next-page`      |
+| <key><</key> | `ytel-search-previous-page`  |
+| <key>s</key> | `ytel-rotate-date`           |
+| <key>s</key> | `ytel-rotate-date-backwards` |
 
 Pressing `s` will prompt for some search terms and populate the buffer once the results are available. One can access information about a video via the function `ytel-get-current-video` that returns the video at point. Videos returned by `ytel-get-current-video` are cl-structures so you can access their fields with the `ytel-video-*` functions. Currently videos have four fields:
 

--- a/ytel.el
+++ b/ytel.el
@@ -219,6 +219,16 @@ too long).")
   (setf ytel-videos (ytel--query ytel-search-term ytel-current-page))
   (ytel--draw-buffer))
 
+(defun ytel-region-search ()
+  "Search youtube for marked region."
+  (interactive )
+  (let* ((query
+	  (buffer-substring-no-properties
+	   (region-beginning)
+	   (region-end))))
+    (ytel)
+    (ytel-search query)))
+
 (defun ytel-search-next-page ()
   "Switch to the next page of the current search.  Redraw the buffer."
   (interactive)

--- a/ytel.el
+++ b/ytel.el
@@ -221,7 +221,7 @@ too long).")
 
 (defun ytel-region-search ()
   "Search youtube for marked region."
-  (interactive )
+  (interactive)
   (let* ((query
 	  (buffer-substring-no-properties
 	   (region-beginning)

--- a/ytel.el
+++ b/ytel.el
@@ -140,7 +140,7 @@ too long).")
 			       (concat name
 				       (make-string (abs extra-chars) ?\ )
 				       "   ")
-			     (concat (seq-subseq name 0 ytel-author-name-reserved-space)
+			     (concat (truncate-string-to-width name ytel-author-name-reserved-space)
 				     "..."))))
     (propertize formatted-string 'face 'ytel-channel-name-face)))
 
@@ -152,7 +152,7 @@ too long).")
 			       (concat title
 				       (make-string (abs extra-chars) ?\ )
 				       "   ")
-			     (concat (seq-subseq title 0 ytel-title-video-reserved-space)
+			     (concat (truncate-string-to-width title ytel-title-video-reserved-space)
 				     "..."))))
     formatted-string))
 

--- a/ytel.el
+++ b/ytel.el
@@ -225,7 +225,8 @@ too long).")
   (let* ((query
 	  (buffer-substring-no-properties
 	   (region-beginning)
-	   (region-end))))
+	   (region-end)))
+	 (ytel-search-term query))
     (ytel)
     (ytel-search query)))
 


### PR DESCRIPTION
For details look at the commits, I also have the fix for the #12 which replaces seq-subseq with truncate-string-to-width which also publobc-mx came to the same conclusion independent from me when I look at his pull request. And it would close also #10.

I understand your hesitence to fiddle with the unicode stuff, but it literally breaks the core functionality, you get a error and it does stop to work. That is a high priority bug, and so far I seen no proof that the fix introduces regressions, if we find such regressions that also cause error and breaking of functionality you can revert that one commit easily.

My PR is much smaller pablobc and don't change much of the structure so I suggest to wink it through fast.